### PR TITLE
Bump version to 9c

### DIFF
--- a/jconfig.h.meson
+++ b/jconfig.h.meson
@@ -1,0 +1,59 @@
+/* jconfig.cfg --- source file edited by configure script */
+/* see jconfig.txt for explanations */
+
+#mesondefine HAVE_PROTOTYPES
+#mesondefine HAVE_UNSIGNED_CHAR
+#mesondefine HAVE_UNSIGNED_SHORT
+#mesondefine void
+#mesondefine const
+#mesondefine CHAR_IS_UNSIGNED
+#mesondefine HAVE_STDDEF_H
+#mesondefine HAVE_STDLIB_H
+#mesondefine HAVE_LOCALE_H
+#mesondefine NEED_BSD_STRINGS
+#mesondefine NEED_SYS_TYPES_H
+#mesondefine NEED_FAR_POINTERS
+#mesondefine NEED_SHORT_EXTERNAL_NAMES
+/* Define this if you get warnings about undefined structures. */
+#mesondefine INCOMPLETE_TYPES_BROKEN
+
+/* Define "boolean" as unsigned char, not enum, on Windows systems. */
+#ifdef _WIN32
+#ifndef __RPCNDR_H__		/* don't conflict if rpcndr.h already read */
+typedef unsigned char boolean;
+#endif
+#ifndef FALSE			/* in case these macros already exist */
+#define FALSE	0		/* values of boolean */
+#endif
+#ifndef TRUE
+#define TRUE	1
+#endif
+#define HAVE_BOOLEAN		/* prevent jmorecfg.h from redefining it */
+#endif
+
+#ifdef JPEG_INTERNALS
+
+#mesondefine RIGHT_SHIFT_IS_UNSIGNED
+#mesondefine INLINE
+/* These are for configuring the JPEG memory manager. */
+#mesondefine DEFAULT_MAX_MEM
+#mesondefine NO_MKTEMP
+
+#endif /* JPEG_INTERNALS */
+
+#ifdef JPEG_CJPEG_DJPEG
+
+#define BMP_SUPPORTED		/* BMP image file format */
+#define GIF_SUPPORTED		/* GIF image file format */
+#define PPM_SUPPORTED		/* PBMPLUS PPM/PGM image file format */
+#undef RLE_SUPPORTED		/* Utah RLE image file format */
+#define TARGA_SUPPORTED		/* Targa image file format */
+
+#mesondefine TWO_FILE_COMMANDLINE
+#mesondefine NEED_SIGNAL_CATCHER
+#mesondefine DONT_USE_B_MODE
+
+/* Define this if you want percent-done progress reports from cjpeg/djpeg. */
+#mesondefine PROGRESS_REPORT
+
+#endif /* JPEG_CJPEG_DJPEG */

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,115 @@
+project('libjpeg', 'c')
+
+sources = [
+  'jaricom.c', 'jcapimin.c', 'jcapistd.c', 'jcarith.c', 'jccoefct.c', 'jccolor.c',
+  'jcdctmgr.c', 'jchuff.c', 'jcinit.c', 'jcmainct.c', 'jcmarker.c', 'jcmaster.c',
+  'jcomapi.c', 'jcparam.c', 'jcprepct.c', 'jcsample.c', 'jctrans.c', 'jdapimin.c',
+  'jdapistd.c', 'jdarith.c', 'jdatadst.c', 'jdatasrc.c', 'jdcoefct.c', 'jdcolor.c',
+  'jddctmgr.c', 'jdhuff.c', 'jdinput.c', 'jdmainct.c', 'jdmarker.c', 'jdmaster.c',
+  'jdmerge.c', 'jdpostct.c', 'jdsample.c', 'jdtrans.c', 'jerror.c', 'jfdctflt.c',
+  'jfdctfst.c', 'jfdctint.c', 'jidctflt.c', 'jidctfst.c', 'jidctint.c', 'jquant1.c',
+  'jquant2.c', 'jutils.c', 'jmemmgr.c',
+]
+
+memmgr_sources = ['jmemansi.c']
+
+cc = meson.get_compiler('c')
+cdata = configuration_data()
+cdata.set('HAVE_PROTOTYPES', true)
+cdata.set('HAVE_UNSIGNED_CHAR', true)
+cdata.set('HAVE_UNSIGNED_SHORT', true)
+cdata.set('HAVE_STDDEF_H', true)
+cdata.set('HAVE_STDLIB_H', true)
+cdata.set('HAVE_LOCALE_H', cc.has_header('locale.h'))
+cdata.set('NEED_FAR_POINTERS', false)
+cdata.set('NEED_SHORT_EXTERNAL_NAMES', false)
+
+signed_char_code = '''
+#include <stdlib.h>
+#include <stdio.h>
+
+int is_char_signed (int arg)
+{
+  if (arg == 189) {		/* expected result for unsigned char */
+    return 0;			/* type char is unsigned */
+  }
+  else if (arg != -67) {	/* expected result for signed char */
+    printf("Hmm, it seems 'char' is not eight bits wide on your machine.\n");
+    printf("I fear the JPEG software will not work at all.\n\n");
+  }
+  return 1;			/* assume char is signed otherwise */
+}
+char signed_char_check = (char) (-67);
+int main() {
+  exit(is_char_signed((int) signed_char_check));
+}
+'''
+
+shift_code = '''
+#include <stdlib.h>
+#include <stdio.h>
+int is_shifting_signed (long arg)
+/* See whether right-shift on a long is signed or not. */
+{
+  long res = arg >> 4;
+
+  if (res == -0x7F7E80CL) {	/* expected result for signed shift */
+    return 1;			/* right shift is signed */
+  }
+  /* see if unsigned-shift hack will fix it. */
+  /* we can't just test exact value since it depends on width of long... */
+  res |= (~0L) << (32-4);
+  if (res == -0x7F7E80CL) {	/* expected result now? */
+    return 0;			/* right shift is unsigned */
+  }
+  printf("Right shift isn't acting as I expect it to.\n");
+  printf("I fear the JPEG software will not work at all.\n\n");
+  return 0;			/* try it with unsigned anyway */
+}
+int main() {
+  exit(is_shifting_signed(-0x7F7E80B1L));
+}
+'''
+
+cdata.set('CHAR_IS_UNSIGNED', cc.run(signed_char_code).returncode() == 0)
+cdata.set('RIGHT_SHIFT_IS_UNSIGNED', cc.run(shift_code).returncode() == 0)
+
+configure_file(input : 'jconfig.h.meson',
+  output : 'jconfig.h',
+  configuration : cdata)
+
+if get_option('shared_lib')
+  libtype = 'shared_library'
+else
+  libtype = 'static_library'
+endif
+
+jpeg = build_target('jpeg',
+  sources, memmgr_sources,
+  target_type : libtype,
+)
+
+cjpeg = executable('cjpeg',
+  'cjpeg.c', 'rdppm.c', 'rdgif.c', 'rdtarga.c', 'rdrle.c', 'rdbmp.c',
+  'rdswitch.c', 'cdjpeg.c',
+  link_with : jpeg
+)
+
+djpeg = executable('djpeg',
+  'djpeg.c', 'wrppm.c', 'wrgif.c', 'wrtarga.c', 'wrrle.c', 'wrbmp.c',
+  'rdcolmap.c', 'cdjpeg.c',
+  link_with : jpeg,
+)
+
+jpegtran = executable('jpegtran',
+  'jpegtran.c', 'rdswitch.c', 'cdjpeg.c', 'transupp.c',
+  link_with : jpeg,
+)
+
+rdjpgcom = executable('rdjpgcom', 'rdjpgcom.c',
+  link_with : jpeg,
+)
+
+wrjpgcom = executable('wrjpgcom', 'wrjpgcom.c',
+  link_with : jpeg,
+)

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('libjpeg', 'c')
+project('libjpeg', 'c', version : '9a', license : 'bsd-like')
 
 sources = [
   'jaricom.c', 'jcapimin.c', 'jcapistd.c', 'jcarith.c', 'jccoefct.c', 'jccolor.c',
@@ -78,15 +78,8 @@ configure_file(input : 'jconfig.h.meson',
   output : 'jconfig.h',
   configuration : cdata)
 
-if get_option('shared_lib')
-  libtype = 'shared_library'
-else
-  libtype = 'static_library'
-endif
-
-jpeg = build_target('jpeg',
+jpeg = library('jpeg',
   sources, memmgr_sources,
-  target_type : libtype,
 )
 
 cjpeg = executable('cjpeg',
@@ -113,3 +106,4 @@ rdjpgcom = executable('rdjpgcom', 'rdjpgcom.c',
 wrjpgcom = executable('wrjpgcom', 'wrjpgcom.c',
   link_with : jpeg,
 )
+

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('libjpeg', 'c', version : '9a', license : 'bsd-like')
+project('libjpeg', 'c', version : '9c', license : 'bsd-like')
 
 sources = [
   'jaricom.c', 'jcapimin.c', 'jcapistd.c', 'jcarith.c', 'jccoefct.c', 'jccolor.c',
@@ -82,28 +82,32 @@ jpeg = library('jpeg',
   sources, memmgr_sources,
 )
 
+jpeg_dep = declare_dependency(
+  include_directories : include_directories('.'),
+  link_with : jpeg
+)
+
 cjpeg = executable('cjpeg',
   'cjpeg.c', 'rdppm.c', 'rdgif.c', 'rdtarga.c', 'rdrle.c', 'rdbmp.c',
   'rdswitch.c', 'cdjpeg.c',
-  link_with : jpeg
+  dependencies : jpeg_dep
 )
 
 djpeg = executable('djpeg',
   'djpeg.c', 'wrppm.c', 'wrgif.c', 'wrtarga.c', 'wrrle.c', 'wrbmp.c',
   'rdcolmap.c', 'cdjpeg.c',
-  link_with : jpeg,
+  dependencies : jpeg_dep
 )
 
 jpegtran = executable('jpegtran',
   'jpegtran.c', 'rdswitch.c', 'cdjpeg.c', 'transupp.c',
-  link_with : jpeg,
+  dependencies : jpeg_dep
 )
 
 rdjpgcom = executable('rdjpgcom', 'rdjpgcom.c',
-  link_with : jpeg,
+  dependencies : jpeg_dep
 )
 
 wrjpgcom = executable('wrjpgcom', 'wrjpgcom.c',
-  link_with : jpeg,
+  dependencies : jpeg_dep
 )
-

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,0 @@
-option('shared_lib', type : 'boolean', value : false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('shared_lib', type : 'boolean', value : false)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = jpeg-9a
+
+source_url = http://ijg.org/files/jpegsrc.v9a.tar.gz
+source_filename = jpegsrc.v9a.tar.gz
+source_hash = 3a753ea48d917945dd54a2d97de388aa06ca2eb1066cbfdc6652036349fe05a7

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,6 +1,6 @@
 [wrap-file]
-directory = jpeg-9a
+directory = jpeg-9c
 
-source_url = http://ijg.org/files/jpegsrc.v9a.tar.gz
-source_filename = jpegsrc.v9a.tar.gz
-source_hash = 3a753ea48d917945dd54a2d97de388aa06ca2eb1066cbfdc6652036349fe05a7
+source_url = http://ijg.org/files/jpegsrc.v9c.tar.gz
+source_filename = jpegsrc.v9c.tar.gz
+source_hash = 650250979303a649e21f87b5ccd02672af1ea6954b911342ea491f351ceb7122


### PR DESCRIPTION
This is a `9c` branch based upon `9a`. It just bumps the source tarball to `jpeg9c`, changes the version hints from 9a to 9c and adds a new `jpeg_dep` object which was previously missing and uses it for linking the applications.
