### PR TITLE
update checksums after the IJG sneakily modified a historic release archive

### DIFF
--- a/upstream.wrap
+++ b/upstream.wrap
@@ -3,7 +3,7 @@ directory = jpeg-9c
 
 source_url = http://ijg.org/files/jpegsrc.v9c.tar.gz
 source_filename = jpegsrc.v9c.tar.gz
-source_hash = 650250979303a649e21f87b5ccd02672af1ea6954b911342ea491f351ceb7122
+source_hash = 1e9793e1c6ba66e7e0b6e5fe7fd0f9e935cc697854d5737adec54d93e5b3f730
 
 [provide]
 libjpeg = jpeg_dep


### PR DESCRIPTION
tl;dr changes are not malicious

A copy of the old source tarball can be retrieved (currently) from http://sources.buildroot.net/libjpeg/jpegsrc.v9c.tar.gz and used to
independently verify the changes.

diffoscope and diff -u indicate the archive is identical, save that several files had the bytes `<8B><AF><A8>` recently removed from the beginning of the file. Of note: the file metadata still claims to have the same modification dates for each changed file, but the top directory is modified

```
-2018-03-27 13:26:05.000000
+2021-01-07 12:11:28.000000
```

Full analysis can be found at https://github.com/mesonbuild/wrapdb/issues/94

I'd be incredibly depressed that the IJG are playing stupid monkey games, except that the IJG is inherently a bunch of monkeys playing games so I can't even be surprised:

https://libjpeg-turbo.org/About/Jpeg-9
https://libjpeg-turbo.org/About/FUD

Gah!